### PR TITLE
Fix nullpointer if external token issuer is not equal to alias of con…

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
@@ -738,6 +738,10 @@ public class DefaultTokenExchangeProvider implements TokenExchangeProvider {
                                                     AtomicReference<IdentityProviderModel> externalIdpModel) {
 
         IdentityProviderModel idpModel = session.identityProviders().getByAlias(alias);
+        if (idpModel == null) {
+            // no external provider available by alias
+            return;
+        }
         IdentityProvider idp = IdentityBrokerService.getIdentityProviderFactory(session, idpModel).create(session, idpModel);
         if (idp instanceof ExchangeExternalToken) {
             externalIdp.set((ExchangeExternalToken) idp);


### PR DESCRIPTION
…figured provider

An external token provider can be located by alias or by issuer. If it is not found by alias, avoid using a null reference and try locating the provider by issuer.

Closes #34869

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
